### PR TITLE
perf: use single TF listener & add singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ ros2 run managed_transform_buffer example_managed_transform_buffer --ros-args -p
 
 ## Limitations
 
-- Requests for dynamic transforms with zero timeout might never succeed. This limitation is due to the fact that the listener is initialized for each transform request (till first occurence of dynamic transform). If timeout is zero, the listener might not have enought time to fill the buffer.
+- Requests for dynamic transforms with zero timeout might never succeed. This limitation is due to the fact that the listener is initialized for each transform request (till first occurrence of dynamic transform). If timeout is zero, the listener might not have enough time to fill the buffer.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This package contains a wrapper of ROS 2 TF buffer & listener. It offers better pefromance
+This package contains a wrapper of ROS 2 TF buffer & listener. It offers better performance
 in large systems with multiple TF listeners to static transformations.
 
 ![Managed Transform Buffer](https://github.com/user-attachments/assets/b8c29b6a-fc77-4941-a50b-8aa30fdc2e36)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 ## Purpose
 
-This package contains a wrapper of ROS 2 TF buffer & listener. It offers better performance
-in large systems with multiple TF listeners to static transformations.
+This package contains a wrapper of ROS 2 TF buffer & listener. It offers better performance in large systems with multiple TF listeners.
 
 ![Managed Transform Buffer](https://github.com/user-attachments/assets/b8c29b6a-fc77-4941-a50b-8aa30fdc2e36)
+
+Apart from the obvious benefits in cases of static-only transformations, it also boosts performance for scenarios with Composable Node Containers thanks to the use of the Singleton pattern.
 
 ## Installation
 
@@ -22,12 +23,12 @@ Library exposes a few handy function for handling TFs and PointCloud2 transforma
 
 ```cpp
 // Create a managed TF buffer
-auto managed_tf_buffer = std::make_unique<ManagedTFBuffer>(node);
+auto managed_tf_buffer = std::make_unique<ManagedTFBuffer>(this->get_clock());
 
 // Get a transform from source_frame to target_frame
-auto tf_msg_transform = managed_tf_buffer->getTransform<geometry_msgs::msg::TransformStamped>("my_target_frame", "my_source_frame");
-auto tf2_transform = managed_tf_buffer->getTransform<tf2::Transform>("my_target_frame", "my_source_frame");
-auto eigen_transform = managed_tf_buffer->getTransform<Eigen::Matrix4f>("my_target_frame", "my_source_frame");
+auto tf_msg_transform = managed_tf_buffer->getTransform<geometry_msgs::msg::TransformStamped>("my_target_frame", "my_source_frame", this->now(), rclcpp::Duration::from_seconds(1));
+auto tf2_transform = managed_tf_buffer->getTransform<tf2::Transform>("my_target_frame", "my_source_frame", this->now(), rclcpp::Duration::from_seconds(1));
+auto eigen_transform = managed_tf_buffer->getTransform<Eigen::Matrix4f>("my_target_frame", "my_source_frame", this->now(), rclcpp::Duration::from_seconds(1));
 
 if (tf_msg_transform.has_value())
 {
@@ -36,7 +37,7 @@ if (tf_msg_transform.has_value())
 
 // Transform a PointCloud2 message
 sensor_msgs::msg::PointCloud2 transformed_cloud;
-auto success = managed_tf_buffer->transformPointcloud("my_target_frame", *in_cloud_msg, transformed_cloud);
+auto success = managed_tf_buffer->transformPointcloud("my_target_frame", *in_cloud_msg, transformed_cloud, this->now(), rclcpp::Duration::from_seconds(1));
 ```
 
 For full example, see [example_managed_transform_buffer.cpp](managed_transform_buffer/examples/example_managed_transform_buffer.cpp).
@@ -46,3 +47,7 @@ You can also build this example and run it:
 colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_EXAMPLES=On --packages-select managed_transform_buffer
 ros2 run managed_transform_buffer example_managed_transform_buffer --ros-args -p target_frame:=my_target_frame -p source_frame:=my_source_frame -r input/cloud:=/my_input_cloud -r output/cloud:=/my_output_cloud
 ```
+
+## Limitations
+
+- Requests for dynamic transforms with zero timeout might never succeed. This limitation is due to the fact that the listener is initialized for each transform request (till first occurence of dynamic transform). If timeout is zero, the listener might not have enought time to fill the buffer.

--- a/managed_transform_buffer/CMakeLists.txt
+++ b/managed_transform_buffer/CMakeLists.txt
@@ -16,6 +16,7 @@ ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/managed_transform_buffer.cpp
+  src/managed_transform_buffer_provider.cpp
 )
 
 if(BUILD_TESTING)

--- a/managed_transform_buffer/include/managed_transform_buffer/managed_transform_buffer.hpp
+++ b/managed_transform_buffer/include/managed_transform_buffer/managed_transform_buffer.hpp
@@ -17,76 +17,23 @@
 #ifndef MANAGED_TRANSFORM_BUFFER__MANAGED_TRANSFORM_BUFFER_HPP_
 #define MANAGED_TRANSFORM_BUFFER__MANAGED_TRANSFORM_BUFFER_HPP_
 
+#include "managed_transform_buffer/managed_transform_buffer_provider.hpp"
+
 #include <eigen3/Eigen/Core>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Transform.hpp>
 
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 
-#include <tf2/LinearMath/Transform.h>
-#include <tf2_ros/buffer.h>
-
-#include <chrono>
-#include <functional>
-#include <memory>
 #include <optional>
-#include <random>
 #include <string>
-#include <thread>
 #include <type_traits>
-#include <unordered_map>
-#include <utility>
-
-namespace std
-{
-template <>
-struct hash<std::pair<std::string, std::string>>
-{
-  size_t operator()(const std::pair<std::string, std::string> & p) const
-  {
-    size_t h1 = std::hash<std::string>{}(p.first);
-    size_t h2 = std::hash<std::string>{}(p.second);
-    return h1 ^ (h2 << 1u);
-  }
-};
-}  // namespace std
 
 namespace managed_transform_buffer
 {
-using Key = std::pair<std::string, std::string>;
-struct PairEqual
-{
-  bool operator()(const Key & p1, const Key & p2) const
-  {
-    return p1.first == p2.first && p1.second == p2.second;
-  }
-};
-struct TreeNode
-{
-  TreeNode() : is_static(false) {}
-  TreeNode(std::string p_parent, const bool p_is_static)
-  : parent(std::move(p_parent)), is_static(p_is_static)
-  {
-  }
-  std::string parent;
-  bool is_static;
-};
-
-struct TraverseResult
-{
-  TraverseResult() : success(false), is_static(false) {}
-  TraverseResult(const bool p_success, const bool p_is_static)
-  : success(p_success), is_static(p_is_static)
-  {
-  }
-  bool success;
-  bool is_static;
-};
-using std::chrono_literals::operator""ms;
 using geometry_msgs::msg::TransformStamped;
-using TFMap = std::unordered_map<Key, TransformStamped, std::hash<Key>, PairEqual>;
-using TreeMap = std::unordered_map<std::string, TreeNode>;
 
 /**
  * @brief A managed TF buffer that handles listener node lifetime. This buffer triggers listener
@@ -199,108 +146,7 @@ public:
   bool isStatic() const;
 
 private:
-  /** @brief Initialize TF listener */
-  void activateListener();
-
-  /** @brief Deactivate TF listener */
-  void deactivateListener();
-
-  /** @brief Register TF buffer as unknown. */
-  void registerAsUnknown();
-
-  /** @brief Register TF buffer as dynamic. */
-  void registerAsDynamic();
-
-  /** @brief Generate a unique node name
-   *
-   * @return a unique node name
-   */
-  std::string generateUniqueNodeName();
-
-  /** @brief Callback for TF messages
-   *
-   * @param[in] msg the TF message
-   * @param[in] is_static whether the TF topic refers to static transforms
-   */
-  void tfCallback(const tf2_msgs::msg::TFMessage::SharedPtr msg, const bool is_static);
-
-  /** @brief Default ROS-ish lookupTransform trigger.
-   *
-   * @param[in] target_frame the frame to which data should be transformed
-   * @param[in] source_frame the frame where the data originated
-   * @param[in] time the time at which the value of the transform is desired (0 will get the latest)
-   * @param[in] timeout how long to block before failing
-   * @return an optional containing the transform if successful, or empty if not
-   */
-  std::optional<TransformStamped> lookupTransform(
-    const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
-    const tf2::Duration & timeout) const;
-
-  /** @brief Traverse TF tree built by local TF listener.
-   *
-   * @param[in] target_frame the frame to which data should be transformed
-   * @param[in] source_frame the frame where the data originated
-   * @param[in] timeout how long to block before failing
-   * @return a traverse result indicating if the transform is possible and if it is static
-   */
-  TraverseResult traverseTree(
-    const std::string & target_frame, const std::string & source_frame,
-    const tf2::Duration & timeout);
-
-  /** @brief Get a dynamic transform from the TF buffer.
-   *
-   * @param[in] target_frame the frame to which data should be transformed
-   * @param[in] source_frame the frame where the data originated
-   * @param[in] time the time at which the value of the transform is desired (0 will get the latest)
-   * @param[in] timeout how long to block before failing
-   * @return an optional containing the transform if successful, or empty if not
-   */
-  std::optional<TransformStamped> getDynamicTransform(
-    const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
-    const tf2::Duration & timeout);
-
-  /** @brief Get a static transform from local TF buffer.
-   *
-   * @param[in] target_frame the frame to which data should be transformed
-   * @param[in] source_frame the frame where the data originated
-   * @return an optional containing the transform if successful, or empty if not
-   */
-  std::optional<TransformStamped> getStaticTransform(
-    const std::string & target_frame, const std::string & source_frame);
-
-  /** @brief Get an unknown (static or dynamic) transform.
-   *
-   * @param[in] target_frame the frame to which data should be transformed
-   * @param[in] source_frame the frame where the data originated
-   * @param[in] time the time at which the value of the transform is desired (0 will get the latest)
-   * @param[in] timeout how long to block before failing
-   * @return an optional containing the transform if successful, or empty if not
-   */
-  std::optional<TransformStamped> getUnknownTransform(
-    const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
-    const tf2::Duration & timeout);
-
-  rclcpp::Node::SharedPtr node_{nullptr};
-  rclcpp::Clock::SharedPtr clock_{nullptr};
-  rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
-  rclcpp::NodeOptions options_;
-  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr tf_static_sub_{nullptr};
-  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr tf_sub_{nullptr};
-  rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>> tf_options_;
-  rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>> tf_static_options_;
-  std::function<std::optional<TransformStamped>(
-    const std::string &, const std::string &, const tf2::TimePoint &, const tf2::Duration &)>
-    get_transform_;
-  std::function<void(tf2_msgs::msg::TFMessage::SharedPtr)> cb_;
-  std::function<void(tf2_msgs::msg::TFMessage::SharedPtr)> cb_static_;
-  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_{nullptr};
-  std::shared_ptr<std::thread> executor_thread_{nullptr};
-  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::unique_ptr<TFMap> static_tf_buffer_;
-  std::unique_ptr<TreeMap> tf_tree_;
-  std::mt19937 random_engine_;
-  std::uniform_int_distribution<> dis_;
-  bool is_static_{true};
+  ManagedTransformBufferProvider * provider_;
 };
 
 }  // namespace managed_transform_buffer

--- a/managed_transform_buffer/include/managed_transform_buffer/managed_transform_buffer_provider.hpp
+++ b/managed_transform_buffer/include/managed_transform_buffer/managed_transform_buffer_provider.hpp
@@ -1,0 +1,235 @@
+// Copyright 2024 The Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Co-developed by Tier IV, Inc.
+
+#ifndef MANAGED_TRANSFORM_BUFFER__MANAGED_TRANSFORM_BUFFER_PROVIDER_HPP_
+#define MANAGED_TRANSFORM_BUFFER__MANAGED_TRANSFORM_BUFFER_PROVIDER_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <tf2_msgs/msg/tf_message.hpp>
+
+#include <tf2_ros/buffer.h>
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <random>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+
+namespace std
+{
+template <>
+struct hash<std::pair<std::string, std::string>>
+{
+  size_t operator()(const std::pair<std::string, std::string> & p) const
+  {
+    size_t h1 = std::hash<std::string>{}(p.first);
+    size_t h2 = std::hash<std::string>{}(p.second);
+    return h1 ^ (h2 << 1u);
+  }
+};
+}  // namespace std
+
+namespace managed_transform_buffer
+{
+using Key = std::pair<std::string, std::string>;
+struct PairEqual
+{
+  bool operator()(const Key & p1, const Key & p2) const
+  {
+    return p1.first == p2.first && p1.second == p2.second;
+  }
+};
+
+struct TreeNode
+{
+  TreeNode() : is_static(false) {}
+  TreeNode(std::string p_parent, const bool p_is_static)
+  : parent(std::move(p_parent)), is_static(p_is_static)
+  {
+  }
+  std::string parent;
+  bool is_static;
+};
+
+struct TraverseResult
+{
+  TraverseResult() : success(false), is_static(false) {}
+  TraverseResult(const bool p_success, const bool p_is_static)
+  : success(p_success), is_static(p_is_static)
+  {
+  }
+  bool success;
+  bool is_static;
+};
+
+using geometry_msgs::msg::TransformStamped;
+using TFMap = std::unordered_map<Key, TransformStamped, std::hash<Key>, PairEqual>;
+using TreeMap = std::unordered_map<std::string, TreeNode>;
+
+/**
+ * @brief A managed TF buffer provider with use of singleton pattern.
+ */
+class ManagedTransformBufferProvider
+{
+public:
+  /** @brief Get the instance of the ManagedTransformBufferProvider
+   *
+   * @return the instance of the ManagedTransformBufferProvider
+   */
+  static ManagedTransformBufferProvider & getInstance(
+    rclcpp::Clock::SharedPtr clock,
+    tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME));
+
+  ManagedTransformBufferProvider(const ManagedTransformBufferProvider &) = delete;
+  ManagedTransformBufferProvider & operator=(const ManagedTransformBufferProvider &) = delete;
+
+  /** @brief Destroy the Managed Transform Buffer object */
+  ~ManagedTransformBufferProvider();
+
+  std::optional<TransformStamped> getTransform(
+    const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
+    const tf2::Duration & timeout);
+
+  /** @brief Check if all TFs requests have been for static TF so far.
+   * @return true if only static TFs have been requested
+   */
+  bool isStatic() const;
+
+private:
+  /**
+   * @brief Construct a new Managed Transform Buffer object
+   *
+   * @param[in] clock A clock to use for time and sleeping
+   * @param[in] cache_time How long to keep a history of transforms
+   */
+  explicit ManagedTransformBufferProvider(
+    rclcpp::Clock::SharedPtr clock,
+    tf2::Duration cache_time = tf2::Duration(tf2::BUFFER_CORE_DEFAULT_CACHE_TIME));
+
+  /** @brief Initialize TF listener */
+  void activateListener();
+
+  /** @brief Deactivate TF listener */
+  void deactivateListener();
+
+  /** @brief Register TF buffer as unknown. */
+  void registerAsUnknown();
+
+  /** @brief Register TF buffer as dynamic. */
+  void registerAsDynamic();
+
+  /** @brief Generate a unique node name
+   *
+   * @return a unique node name
+   */
+  std::string generateUniqueNodeName();
+
+  /** @brief Callback for TF messages
+   *
+   * @param[in] msg the TF message
+   * @param[in] is_static whether the TF topic refers to static transforms
+   */
+  void tfCallback(const tf2_msgs::msg::TFMessage::SharedPtr msg, const bool is_static);
+
+  /** @brief Default ROS-ish lookupTransform trigger.
+   *
+   * @param[in] target_frame the frame to which data should be transformed
+   * @param[in] source_frame the frame where the data originated
+   * @param[in] time the time at which the value of the transform is desired (0 will get the latest)
+   * @param[in] timeout how long to block before failing
+   * @return an optional containing the transform if successful, or empty if not
+   */
+  std::optional<TransformStamped> lookupTransform(
+    const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
+    const tf2::Duration & timeout) const;
+
+  /** @brief Traverse TF tree built by local TF listener.
+   *
+   * @param[in] target_frame the frame to which data should be transformed
+   * @param[in] source_frame the frame where the data originated
+   * @param[in] timeout how long to block before failing
+   * @return a traverse result indicating if the transform is possible and if it is static
+   */
+  TraverseResult traverseTree(
+    const std::string & target_frame, const std::string & source_frame,
+    const tf2::Duration & timeout);
+
+  /** @brief Get a dynamic transform from the TF buffer.
+   *
+   * @param[in] target_frame the frame to which data should be transformed
+   * @param[in] source_frame the frame where the data originated
+   * @param[in] time the time at which the value of the transform is desired (0 will get the latest)
+   * @param[in] timeout how long to block before failing
+   * @return an optional containing the transform if successful, or empty if not
+   */
+  std::optional<TransformStamped> getDynamicTransform(
+    const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
+    const tf2::Duration & timeout);
+
+  /** @brief Get a static transform from local TF buffer.
+   *
+   * @param[in] target_frame the frame to which data should be transformed
+   * @param[in] source_frame the frame where the data originated
+   * @return an optional containing the transform if successful, or empty if not
+   */
+  std::optional<TransformStamped> getStaticTransform(
+    const std::string & target_frame, const std::string & source_frame);
+
+  /** @brief Get an unknown (static or dynamic) transform.
+   *
+   * @param[in] target_frame the frame to which data should be transformed
+   * @param[in] source_frame the frame where the data originated
+   * @param[in] time the time at which the value of the transform is desired (0 will get the latest)
+   * @param[in] timeout how long to block before failing
+   * @return an optional containing the transform if successful, or empty if not
+   */
+  std::optional<TransformStamped> getUnknownTransform(
+    const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
+    const tf2::Duration & timeout);
+
+  static std::unique_ptr<ManagedTransformBufferProvider> instance;
+  rclcpp::Node::SharedPtr node_{nullptr};
+  rclcpp::Clock::SharedPtr clock_{nullptr};
+  rclcpp::CallbackGroup::SharedPtr callback_group_{nullptr};
+  rclcpp::NodeOptions options_;
+  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr tf_static_sub_{nullptr};
+  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr tf_sub_{nullptr};
+  rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>> tf_options_;
+  rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>> tf_static_options_;
+  std::function<std::optional<TransformStamped>(
+    const std::string &, const std::string &, const tf2::TimePoint &, const tf2::Duration &)>
+    get_transform_;
+  std::function<void(tf2_msgs::msg::TFMessage::SharedPtr)> cb_;
+  std::function<void(tf2_msgs::msg::TFMessage::SharedPtr)> cb_static_;
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_{nullptr};
+  std::shared_ptr<std::thread> executor_thread_{nullptr};
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::unique_ptr<TFMap> static_tf_buffer_;
+  std::unique_ptr<TreeMap> tf_tree_;
+  std::mt19937 random_engine_;
+  std::uniform_int_distribution<> dis_;
+  std::mutex mutex_;
+  bool is_static_{true};
+};
+
+}  // namespace managed_transform_buffer
+
+#endif  // MANAGED_TRANSFORM_BUFFER__MANAGED_TRANSFORM_BUFFER_PROVIDER_HPP_

--- a/managed_transform_buffer/src/managed_transform_buffer.cpp
+++ b/managed_transform_buffer/src/managed_transform_buffer.cpp
@@ -17,61 +17,28 @@
 #include "managed_transform_buffer/managed_transform_buffer.hpp"
 
 #include <pcl_ros/transforms.hpp>
-#include <tf2_ros/qos.hpp>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2/convert.h>
-#include <tf2/exceptions.h>
-#include <tf2_ros/create_timer_ros.h>
-
-#include <atomic>
-#include <cstdint>
-#include <future>
-#include <string>
 
 namespace managed_transform_buffer
 {
 
 ManagedTransformBuffer::ManagedTransformBuffer(
   rclcpp::Clock::SharedPtr clock, tf2::Duration cache_time)
-: clock_(clock)
 {
-  executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-  executor_thread_ = std::make_shared<std::thread>(
-    std::bind(&rclcpp::executors::SingleThreadedExecutor::spin, executor_));
-
-  static_tf_buffer_ = std::make_unique<TFMap>();
-  tf_tree_ = std::make_unique<TreeMap>();
-  tf_buffer_ = std::make_unique<tf2_ros::Buffer>(clock_, cache_time);
-  tf_buffer_->setUsingDedicatedThread(true);
-  tf_options_ = tf2_ros::detail::get_default_transform_listener_sub_options();
-  tf_static_options_ = tf2_ros::detail::get_default_transform_listener_static_sub_options();
-  cb_ = std::bind(&ManagedTransformBuffer::tfCallback, this, std::placeholders::_1, false);
-  cb_static_ = std::bind(&ManagedTransformBuffer::tfCallback, this, std::placeholders::_1, true);
-  options_.start_parameter_event_publisher(false);
-  options_.start_parameter_services(false);
-  random_engine_ = std::mt19937(std::random_device{}());
-  dis_ = std::uniform_int_distribution<>(0, 0xFFFFFF);
-  registerAsUnknown();
+  provider_ = &ManagedTransformBufferProvider::getInstance(clock, cache_time);
 }
 
-ManagedTransformBuffer::~ManagedTransformBuffer()
-{
-  deactivateListener();
-  executor_->cancel();
-  if (executor_thread_->joinable()) {
-    executor_thread_->join();
-  }
-}
+ManagedTransformBuffer::~ManagedTransformBuffer() = default;
 
 template <>
 std::optional<TransformStamped> ManagedTransformBuffer::getTransform<TransformStamped>(
   const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
   const tf2::Duration & timeout)
 {
-  return get_transform_(target_frame, source_frame, time, timeout);
+  return provider_->getTransform(target_frame, source_frame, time, timeout);
 }
 
 template <>
@@ -79,7 +46,7 @@ std::optional<Eigen::Matrix4f> ManagedTransformBuffer::getTransform<Eigen::Matri
   const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
   const tf2::Duration & timeout)
 {
-  auto tf = get_transform_(target_frame, source_frame, time, timeout);
+  auto tf = provider_->getTransform(target_frame, source_frame, time, timeout);
   if (!tf.has_value()) {
     return std::nullopt;
   }
@@ -93,7 +60,7 @@ std::optional<tf2::Transform> ManagedTransformBuffer::getTransform<tf2::Transfor
   const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
   const tf2::Duration & timeout)
 {
-  auto tf = get_transform_(target_frame, source_frame, time, timeout);
+  auto tf = provider_->getTransform(target_frame, source_frame, time, timeout);
   if (!tf.has_value()) {
     return std::nullopt;
   }
@@ -164,277 +131,7 @@ bool ManagedTransformBuffer::transformPointcloud(
 
 bool ManagedTransformBuffer::isStatic() const
 {
-  return is_static_;
-}
-
-void ManagedTransformBuffer::activateListener()
-{
-  options_.arguments({"--ros-args", "-r", "__node:=" + generateUniqueNodeName()});
-  node_ = rclcpp::Node::make_unique("_", options_);
-  callback_group_ =
-    node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
-  tf_options_.callback_group = callback_group_;
-  tf_static_options_.callback_group = callback_group_;
-  tf_sub_ = node_->create_subscription<tf2_msgs::msg::TFMessage>(
-    "/tf", tf2_ros::DynamicListenerQoS(), cb_, tf_options_);
-  tf_static_sub_ = node_->create_subscription<tf2_msgs::msg::TFMessage>(
-    "/tf_static", tf2_ros::StaticListenerQoS(), cb_static_, tf_static_options_);
-  executor_->add_callback_group(callback_group_, node_->get_node_base_interface());
-}
-
-void ManagedTransformBuffer::deactivateListener()
-{
-  auto cb_grps = executor_->get_all_callback_groups();
-  for (auto & cb_grp : cb_grps) {
-    executor_->remove_callback_group(cb_grp.lock());
-  }
-  tf_static_sub_.reset();
-  tf_sub_.reset();
-  node_.reset();
-}
-
-void ManagedTransformBuffer::registerAsUnknown()
-{
-  get_transform_ = [this](
-                     const std::string & target_frame, const std::string & source_frame,
-                     const tf2::TimePoint & time,
-                     const tf2::Duration & timeout) -> std::optional<TransformStamped> {
-    return getUnknownTransform(target_frame, source_frame, time, timeout);
-  };
-}
-
-void ManagedTransformBuffer::registerAsDynamic()
-{
-  is_static_ = false;
-  get_transform_ = [this](
-                     const std::string & target_frame, const std::string & source_frame,
-                     const tf2::TimePoint & time,
-                     const tf2::Duration & timeout) -> std::optional<TransformStamped> {
-    if (!node_) {
-      activateListener();
-    }
-    return getDynamicTransform(target_frame, source_frame, time, timeout);
-  };
-}
-
-std::string ManagedTransformBuffer::generateUniqueNodeName()
-{
-  std::stringstream sstream;
-  sstream << "managed_tf_listener_impl_" << std::hex << dis_(random_engine_)
-          << dis_(random_engine_);
-  return sstream.str();
-}
-
-void ManagedTransformBuffer::tfCallback(
-  const tf2_msgs::msg::TFMessage::SharedPtr msg, const bool is_static)
-{
-  std::string authority = "Authority undetectable";
-  for (const auto & tf : msg->transforms) {
-    try {
-      tf_buffer_->setTransform(tf, authority, is_static);
-      tf_tree_->emplace(tf.child_frame_id, TreeNode{tf.header.frame_id, is_static});
-    } catch (const tf2::TransformException & ex) {
-      if (node_) {
-        RCLCPP_ERROR(
-          node_->get_logger(), "Failure to set received transform from %s to %s with error: %s\n",
-          tf.child_frame_id.c_str(), tf.header.frame_id.c_str(), ex.what());
-      }
-    }
-  }
-}
-
-std::optional<TransformStamped> ManagedTransformBuffer::lookupTransform(
-  const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
-  const tf2::Duration & timeout) const
-{
-  try {
-    auto tf = tf_buffer_->lookupTransform(target_frame, source_frame, time, timeout);
-    return std::make_optional<TransformStamped>(tf);
-  } catch (const tf2::TransformException & ex) {
-    if (node_) {
-      RCLCPP_ERROR(
-        node_->get_logger(), "Failure to get transform from %s to %s with error: %s",
-        target_frame.c_str(), source_frame.c_str(), ex.what());
-    }
-    return std::nullopt;
-  }
-}
-
-TraverseResult ManagedTransformBuffer::traverseTree(
-  const std::string & target_frame, const std::string & source_frame, const tf2::Duration & timeout)
-{
-  std::atomic<bool> timeout_reached{false};
-
-  auto framesToRoot = [this](
-                        const std::string & start_frame, TreeMap & last_tf_tree,
-                        std::vector<std::string> & frames_out) -> bool {
-    frames_out.push_back(start_frame);
-    uint32_t depth = 0;
-    auto current_frame = start_frame;
-    auto frame_it = last_tf_tree.find(current_frame);
-    while (frame_it != last_tf_tree.end()) {
-      current_frame = frame_it->second.parent;
-      frames_out.push_back(current_frame);
-      frame_it = last_tf_tree.find(current_frame);
-      depth++;
-      if (depth > tf2::BufferCore::MAX_GRAPH_DEPTH) {
-        if (node_) {
-          RCLCPP_ERROR(node_->get_logger(), "Traverse depth exceeded for %s", start_frame.c_str());
-        }
-        return false;
-      }
-    }
-    return true;
-  };
-
-  auto traverse = [this, &timeout_reached, &framesToRoot](
-                    const std::string & t1, const std::string & t2) -> TraverseResult {
-    while (!timeout_reached) {
-      std::vector<std::string> frames_from_t1;
-      std::vector<std::string> frames_from_t2;
-      auto last_tf_tree = *tf_tree_;
-
-      // Collect all frames from bottom to the top of TF tree for both frames
-      if (
-        !framesToRoot(t1, last_tf_tree, frames_from_t1) ||
-        !framesToRoot(t2, last_tf_tree, frames_from_t2)) {
-        // Possibly TF loop occurred
-        return {false, false};
-      }
-
-      // Find common ancestor
-      bool only_static_requested_from_t1 = true;
-      bool only_static_requested_from_t2 = true;
-      for (auto & frame_from_t1 : frames_from_t1) {
-        auto frame_from_t1_it = last_tf_tree.find(frame_from_t1);
-        if (frame_from_t1_it != last_tf_tree.end()) {  // Otherwise frame is TF root (no parent)
-          only_static_requested_from_t1 &= last_tf_tree.at(frame_from_t1).is_static;
-        }
-        for (auto & frame_from_t2 : frames_from_t2) {
-          auto frame_from_t2_it = last_tf_tree.find(frame_from_t2);
-          if (frame_from_t2_it != last_tf_tree.end()) {  // Otherwise frame is TF root (no parent)
-            only_static_requested_from_t2 &= last_tf_tree.at(frame_from_t2).is_static;
-          }
-          if (frame_from_t1 == frame_from_t2) {
-            return {true, only_static_requested_from_t1 && only_static_requested_from_t2};
-          }
-        }
-        only_static_requested_from_t1 = true;
-        only_static_requested_from_t2 = true;
-      }
-    }
-    // Timeout reached
-    return {false, false};
-  };
-
-  std::future<TraverseResult> future =
-    std::async(std::launch::async, traverse, target_frame, source_frame);
-  if (future.wait_for(timeout) == std::future_status::ready) {
-    return future.get();
-  }
-  timeout_reached = true;
-  return {false, false};
-}
-
-std::optional<TransformStamped> ManagedTransformBuffer::getDynamicTransform(
-  const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
-  const tf2::Duration & timeout)
-{
-  if (!node_) {
-    activateListener();
-  }
-  return lookupTransform(target_frame, source_frame, time, timeout);
-}
-
-std::optional<TransformStamped> ManagedTransformBuffer::getStaticTransform(
-  const std::string & target_frame, const std::string & source_frame)
-{
-  auto key = std::make_pair(target_frame, source_frame);
-  auto key_inv = std::make_pair(source_frame, target_frame);
-
-  // Check if the transform is already in the buffer
-  auto it = static_tf_buffer_->find(key);
-  if (it != static_tf_buffer_->end()) {
-    auto tf_msg = it->second;
-    tf_msg.header.stamp = clock_->now();
-    return std::make_optional<TransformStamped>(tf_msg);
-  }
-
-  // Check if the inverse transform is already in the buffer
-  auto it_inv = static_tf_buffer_->find(key_inv);
-  if (it_inv != static_tf_buffer_->end()) {
-    auto tf_msg = it_inv->second;
-    tf2::Transform tf;
-    tf2::fromMsg(tf_msg.transform, tf);
-    tf2::Transform inv_tf = tf.inverse();
-    TransformStamped inv_tf_msg;
-    inv_tf_msg.transform = tf2::toMsg(inv_tf);
-    inv_tf_msg.header.frame_id = tf_msg.child_frame_id;
-    inv_tf_msg.child_frame_id = tf_msg.header.frame_id;
-    inv_tf_msg.header.stamp = clock_->now();
-    static_tf_buffer_->emplace(key, inv_tf_msg);
-    return std::make_optional<TransformStamped>(inv_tf_msg);
-  }
-
-  // Check if transform is needed
-  if (target_frame == source_frame) {
-    auto tf_identity = tf2::Transform::getIdentity();
-    TransformStamped tf_msg;
-    tf_msg.transform = tf2::toMsg(tf_identity);
-    tf_msg.header.frame_id = target_frame;
-    tf_msg.child_frame_id = source_frame;
-    tf_msg.header.stamp = clock_->now();
-    static_tf_buffer_->emplace(key, tf_msg);
-    return std::make_optional<TransformStamped>(tf_msg);
-  }
-
-  return std::nullopt;
-}
-
-std::optional<TransformStamped> ManagedTransformBuffer::getUnknownTransform(
-  const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
-  const tf2::Duration & timeout)
-{
-  // Try to get transform from local static buffer
-  auto static_tf = getStaticTransform(target_frame, source_frame);
-  if (static_tf.has_value()) {
-    return static_tf;
-  }
-
-  // Initialize local TF listener and base TF listener
-  activateListener();
-
-  // Check local TF tree and TF buffer asynchronously
-  std::future<TraverseResult> traverse_future = std::async(
-    std::launch::async, &ManagedTransformBuffer::traverseTree, this, target_frame, source_frame,
-    timeout);
-  std::future<std::optional<TransformStamped>> tf_future = std::async(
-    std::launch::async, &ManagedTransformBuffer::lookupTransform, this, target_frame, source_frame,
-    time, timeout);
-  auto traverse_result = traverse_future.get();
-  auto tf = tf_future.get();
-
-  // Mimic lookup transform error if TF not exists in tree or buffer
-  if (!traverse_result.success || !tf.has_value()) {
-    deactivateListener();
-    return std::nullopt;
-  }
-
-  // If TF is static, add it to the static buffer. Otherwise, switch to dynamic listener
-  if (traverse_result.is_static) {
-    auto key = std::make_pair(target_frame, source_frame);
-    static_tf_buffer_->emplace(key, tf.value());
-    deactivateListener();
-  } else {
-    registerAsDynamic();
-    if (node_) {
-      RCLCPP_INFO(
-        node_->get_logger(), "Transform %s -> %s is dynamic. Switching to dynamic listener.",
-        target_frame.c_str(), source_frame.c_str());
-    }
-  }
-
-  return tf;
+  return provider_->isStatic();
 }
 
 }  // namespace managed_transform_buffer

--- a/managed_transform_buffer/src/managed_transform_buffer_provider.cpp
+++ b/managed_transform_buffer/src/managed_transform_buffer_provider.cpp
@@ -1,0 +1,361 @@
+// Copyright 2024 The Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Co-developed by Tier IV, Inc.
+
+#include "managed_transform_buffer/managed_transform_buffer_provider.hpp"
+
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/convert.hpp>
+#include <tf2_ros/qos.hpp>
+
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <tf2_ros/transform_listener.h>
+
+#include <atomic>
+#include <cstdint>
+#include <future>
+
+namespace managed_transform_buffer
+{
+
+std::unique_ptr<ManagedTransformBufferProvider> ManagedTransformBufferProvider::instance = nullptr;
+
+ManagedTransformBufferProvider & ManagedTransformBufferProvider::getInstance(
+  rclcpp::Clock::SharedPtr clock, tf2::Duration cache_time)
+{
+  static ManagedTransformBufferProvider instance(clock, cache_time);
+  return instance;
+}
+
+std::optional<TransformStamped> ManagedTransformBufferProvider::getTransform(
+  const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
+  const tf2::Duration & timeout)
+{
+  return get_transform_(target_frame, source_frame, time, timeout);
+}
+
+bool ManagedTransformBufferProvider::isStatic() const
+{
+  return is_static_;
+}
+
+ManagedTransformBufferProvider::ManagedTransformBufferProvider(
+  rclcpp::Clock::SharedPtr clock, tf2::Duration cache_time)
+: clock_(clock)
+{
+  executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  executor_thread_ = std::make_shared<std::thread>(
+    std::bind(&rclcpp::executors::SingleThreadedExecutor::spin, executor_));
+
+  static_tf_buffer_ = std::make_unique<TFMap>();
+  tf_tree_ = std::make_unique<TreeMap>();
+  tf_buffer_ = std::make_unique<tf2_ros::Buffer>(clock_, cache_time);
+  tf_buffer_->setUsingDedicatedThread(true);
+  tf_options_ = tf2_ros::detail::get_default_transform_listener_sub_options();
+  tf_static_options_ = tf2_ros::detail::get_default_transform_listener_static_sub_options();
+  cb_ = std::bind(&ManagedTransformBufferProvider::tfCallback, this, std::placeholders::_1, false);
+  cb_static_ =
+    std::bind(&ManagedTransformBufferProvider::tfCallback, this, std::placeholders::_1, true);
+  options_.start_parameter_event_publisher(false);
+  options_.start_parameter_services(false);
+  random_engine_ = std::mt19937(std::random_device{}());
+  dis_ = std::uniform_int_distribution<>(0, 0xFFFFFF);
+  registerAsUnknown();
+}
+
+ManagedTransformBufferProvider::~ManagedTransformBufferProvider()
+{
+  deactivateListener();
+  executor_->cancel();
+  if (executor_thread_->joinable()) {
+    executor_thread_->join();
+  }
+}
+
+void ManagedTransformBufferProvider::activateListener()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  options_.arguments({"--ros-args", "-r", "__node:=" + generateUniqueNodeName()});
+  node_ = rclcpp::Node::make_unique("_", options_);
+  callback_group_ =
+    node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+  tf_options_.callback_group = callback_group_;
+  tf_options_.use_intra_process_comm = rclcpp::IntraProcessSetting::Enable;
+  tf_static_options_.callback_group = callback_group_;
+  tf_sub_ = node_->create_subscription<tf2_msgs::msg::TFMessage>(
+    "/tf", tf2_ros::DynamicListenerQoS(), cb_, tf_options_);
+  tf_static_sub_ = node_->create_subscription<tf2_msgs::msg::TFMessage>(
+    "/tf_static", tf2_ros::StaticListenerQoS(), cb_static_, tf_static_options_);
+  executor_->add_callback_group(callback_group_, node_->get_node_base_interface());
+}
+
+void ManagedTransformBufferProvider::deactivateListener()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto cb_grps = executor_->get_all_callback_groups();
+  for (auto & cb_grp : cb_grps) {
+    executor_->remove_callback_group(cb_grp.lock());
+  }
+  tf_static_sub_.reset();
+  tf_sub_.reset();
+  node_.reset();
+}
+
+void ManagedTransformBufferProvider::registerAsUnknown()
+{
+  get_transform_ = [this](
+                     const std::string & target_frame, const std::string & source_frame,
+                     const tf2::TimePoint & time,
+                     const tf2::Duration & timeout) -> std::optional<TransformStamped> {
+    return getUnknownTransform(target_frame, source_frame, time, timeout);
+  };
+}
+
+void ManagedTransformBufferProvider::registerAsDynamic()
+{
+  is_static_ = false;
+  get_transform_ = [this](
+                     const std::string & target_frame, const std::string & source_frame,
+                     const tf2::TimePoint & time,
+                     const tf2::Duration & timeout) -> std::optional<TransformStamped> {
+    if (!node_) {
+      activateListener();
+    }
+    return getDynamicTransform(target_frame, source_frame, time, timeout);
+  };
+}
+
+std::string ManagedTransformBufferProvider::generateUniqueNodeName()
+{
+  std::stringstream sstream;
+  sstream << "managed_tf_listener_impl_" << std::hex << dis_(random_engine_)
+          << dis_(random_engine_);
+  return sstream.str();
+}
+
+void ManagedTransformBufferProvider::tfCallback(
+  const tf2_msgs::msg::TFMessage::SharedPtr msg, const bool is_static)
+{
+  std::string authority = "Authority undetectable";
+  for (const auto & tf : msg->transforms) {
+    try {
+      tf_buffer_->setTransform(tf, authority, is_static);
+      tf_tree_->emplace(tf.child_frame_id, TreeNode{tf.header.frame_id, is_static});
+    } catch (const tf2::TransformException & ex) {
+      if (node_) {
+        RCLCPP_ERROR(
+          node_->get_logger(), "Failure to set received transform from %s to %s with error: %s\n",
+          tf.child_frame_id.c_str(), tf.header.frame_id.c_str(), ex.what());
+      }
+    }
+  }
+}
+
+std::optional<TransformStamped> ManagedTransformBufferProvider::lookupTransform(
+  const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
+  const tf2::Duration & timeout) const
+{
+  try {
+    auto tf = tf_buffer_->lookupTransform(target_frame, source_frame, time, timeout);
+    return std::make_optional<TransformStamped>(tf);
+  } catch (const tf2::TransformException & ex) {
+    if (node_) {
+      RCLCPP_ERROR(
+        node_->get_logger(), "Failure to get transform from %s to %s with error: %s",
+        target_frame.c_str(), source_frame.c_str(), ex.what());
+    }
+    return std::nullopt;
+  }
+}
+
+TraverseResult ManagedTransformBufferProvider::traverseTree(
+  const std::string & target_frame, const std::string & source_frame, const tf2::Duration & timeout)
+{
+  std::atomic<bool> timeout_reached{false};
+
+  auto framesToRoot = [this](
+                        const std::string & start_frame, TreeMap & last_tf_tree,
+                        std::vector<std::string> & frames_out) -> bool {
+    frames_out.push_back(start_frame);
+    uint32_t depth = 0;
+    auto current_frame = start_frame;
+    auto frame_it = last_tf_tree.find(current_frame);
+    while (frame_it != last_tf_tree.end()) {
+      current_frame = frame_it->second.parent;
+      frames_out.push_back(current_frame);
+      frame_it = last_tf_tree.find(current_frame);
+      depth++;
+      if (depth > tf2::BufferCore::MAX_GRAPH_DEPTH) {
+        if (node_) {
+          RCLCPP_ERROR(node_->get_logger(), "Traverse depth exceeded for %s", start_frame.c_str());
+        }
+        return false;
+      }
+    }
+    return true;
+  };
+
+  auto traverse = [this, &timeout_reached, &framesToRoot](
+                    const std::string & t1, const std::string & t2) -> TraverseResult {
+    while (!timeout_reached) {
+      std::vector<std::string> frames_from_t1;
+      std::vector<std::string> frames_from_t2;
+      auto last_tf_tree = *tf_tree_;
+
+      // Collect all frames from bottom to the top of TF tree for both frames
+      if (
+        !framesToRoot(t1, last_tf_tree, frames_from_t1) ||
+        !framesToRoot(t2, last_tf_tree, frames_from_t2)) {
+        // Possibly TF loop occurred
+        return {false, false};
+      }
+
+      // Find common ancestor
+      bool only_static_requested_from_t1 = true;
+      bool only_static_requested_from_t2 = true;
+      for (auto & frame_from_t1 : frames_from_t1) {
+        auto frame_from_t1_it = last_tf_tree.find(frame_from_t1);
+        if (frame_from_t1_it != last_tf_tree.end()) {  // Otherwise frame is TF root (no parent)
+          only_static_requested_from_t1 &= last_tf_tree.at(frame_from_t1).is_static;
+        }
+        for (auto & frame_from_t2 : frames_from_t2) {
+          auto frame_from_t2_it = last_tf_tree.find(frame_from_t2);
+          if (frame_from_t2_it != last_tf_tree.end()) {  // Otherwise frame is TF root (no parent)
+            only_static_requested_from_t2 &= last_tf_tree.at(frame_from_t2).is_static;
+          }
+          if (frame_from_t1 == frame_from_t2) {
+            return {true, only_static_requested_from_t1 && only_static_requested_from_t2};
+          }
+        }
+        only_static_requested_from_t1 = true;
+        only_static_requested_from_t2 = true;
+      }
+    }
+    // Timeout reached
+    return {false, false};
+  };
+
+  std::future<TraverseResult> future =
+    std::async(std::launch::async, traverse, target_frame, source_frame);
+  if (future.wait_for(timeout) == std::future_status::ready) {
+    return future.get();
+  }
+  timeout_reached = true;
+  return {false, false};
+}
+
+std::optional<TransformStamped> ManagedTransformBufferProvider::getDynamicTransform(
+  const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
+  const tf2::Duration & timeout)
+{
+  if (!node_) {
+    activateListener();
+  }
+  return lookupTransform(target_frame, source_frame, time, timeout);
+}
+
+std::optional<TransformStamped> ManagedTransformBufferProvider::getStaticTransform(
+  const std::string & target_frame, const std::string & source_frame)
+{
+  auto key = std::make_pair(target_frame, source_frame);
+  auto key_inv = std::make_pair(source_frame, target_frame);
+
+  // Check if the transform is already in the buffer
+  auto it = static_tf_buffer_->find(key);
+  if (it != static_tf_buffer_->end()) {
+    auto tf_msg = it->second;
+    tf_msg.header.stamp = clock_->now();
+    return std::make_optional<TransformStamped>(tf_msg);
+  }
+
+  // Check if the inverse transform is already in the buffer
+  auto it_inv = static_tf_buffer_->find(key_inv);
+  if (it_inv != static_tf_buffer_->end()) {
+    auto tf_msg = it_inv->second;
+    tf2::Transform tf;
+    tf2::fromMsg(tf_msg.transform, tf);
+    tf2::Transform inv_tf = tf.inverse();
+    TransformStamped inv_tf_msg;
+    inv_tf_msg.transform = tf2::toMsg(inv_tf);
+    inv_tf_msg.header.frame_id = tf_msg.child_frame_id;
+    inv_tf_msg.child_frame_id = tf_msg.header.frame_id;
+    inv_tf_msg.header.stamp = clock_->now();
+    static_tf_buffer_->emplace(key, inv_tf_msg);
+    return std::make_optional<TransformStamped>(inv_tf_msg);
+  }
+
+  // Check if transform is needed
+  if (target_frame == source_frame) {
+    auto tf_identity = tf2::Transform::getIdentity();
+    TransformStamped tf_msg;
+    tf_msg.transform = tf2::toMsg(tf_identity);
+    tf_msg.header.frame_id = target_frame;
+    tf_msg.child_frame_id = source_frame;
+    tf_msg.header.stamp = clock_->now();
+    static_tf_buffer_->emplace(key, tf_msg);
+    return std::make_optional<TransformStamped>(tf_msg);
+  }
+
+  return std::nullopt;
+}
+
+std::optional<TransformStamped> ManagedTransformBufferProvider::getUnknownTransform(
+  const std::string & target_frame, const std::string & source_frame, const tf2::TimePoint & time,
+  const tf2::Duration & timeout)
+{
+  // Try to get transform from local static buffer
+  auto static_tf = getStaticTransform(target_frame, source_frame);
+  if (static_tf.has_value()) {
+    return static_tf;
+  }
+
+  // Initialize local TF listener and base TF listener
+  activateListener();
+
+  // Check local TF tree and TF buffer asynchronously
+  std::future<TraverseResult> traverse_future = std::async(
+    std::launch::async, &ManagedTransformBufferProvider::traverseTree, this, target_frame,
+    source_frame, timeout);
+  std::future<std::optional<TransformStamped>> tf_future = std::async(
+    std::launch::async, &ManagedTransformBufferProvider::lookupTransform, this, target_frame,
+    source_frame, time, timeout);
+  auto traverse_result = traverse_future.get();
+  auto tf = tf_future.get();
+
+  // Mimic lookup transform error if TF not exists in tree or buffer
+  if (!traverse_result.success || !tf.has_value()) {
+    deactivateListener();
+    return std::nullopt;
+  }
+
+  // If TF is static, add it to the static buffer. Otherwise, switch to dynamic listener
+  if (traverse_result.is_static) {
+    auto key = std::make_pair(target_frame, source_frame);
+    static_tf_buffer_->emplace(key, tf.value());
+    deactivateListener();
+  } else {
+    registerAsDynamic();
+    if (node_) {
+      RCLCPP_INFO(
+        node_->get_logger(), "Transform %s -> %s is dynamic. Switching to dynamic listener.",
+        target_frame.c_str(), source_frame.c_str());
+    }
+  }
+
+  return tf;
+}
+
+}  // namespace managed_transform_buffer

--- a/managed_transform_buffer/test/test_managed_transform_buffer.cpp
+++ b/managed_transform_buffer/test/test_managed_transform_buffer.cpp
@@ -241,6 +241,8 @@ TEST_F(TestManagedTransformBuffer, TestTransformDynamic)
 
 TEST_F(TestManagedTransformBuffer, TestTransformMultipleCall)
 {
+  EXPECT_FALSE(managed_tf_buffer_->isStatic());
+
   static_tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
 
   std::optional<Eigen::Matrix4f> eigen_transform;
@@ -271,7 +273,6 @@ TEST_F(TestManagedTransformBuffer, TestTransformMultipleCall)
     managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "lidar_top", time_, timeout_);
   ASSERT_TRUE(eigen_transform.has_value());
   EXPECT_TRUE(eigen_transform.value().isApprox(eigen_base_to_lidar_top_, precision_));
-  EXPECT_TRUE(managed_tf_buffer_->isStatic());
 
   std::future<void> future =
     std::async(std::launch::async, [this]() { broadcastDynamicTf(tf_map_to_base_); });
@@ -280,7 +281,6 @@ TEST_F(TestManagedTransformBuffer, TestTransformMultipleCall)
   future.wait();
   ASSERT_TRUE(eigen_map_to_base.has_value());
   EXPECT_TRUE(eigen_map_to_base.value().isApprox(eigen_map_to_base_, precision_));
-  EXPECT_FALSE(managed_tf_buffer_->isStatic());
 
   eigen_transform =
     managed_tf_buffer_->getTransform<Eigen::Matrix4f>("fake_link", "fake_link", time_, timeout_);

--- a/managed_transform_buffer/test/test_managed_transform_buffer.cpp
+++ b/managed_transform_buffer/test/test_managed_transform_buffer.cpp
@@ -27,34 +27,37 @@
 #include <gtest/gtest.h>
 #include <tf2/LinearMath/Transform.h>
 #include <tf2_ros/static_transform_broadcaster.h>
+#include <tf2_ros/transform_broadcaster.h>
 
-#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
 
-std::chrono::milliseconds managed_transform_buffer::ManagedTransformBuffer::default_timeout =
-  std::chrono::milliseconds(100);  // Relax timeout for CI
-
 class TestManagedTransformBuffer : public ::testing::Test
 {
 protected:
-  std::shared_ptr<rclcpp::Node> node_{nullptr};
-  std::shared_ptr<managed_transform_buffer::ManagedTransformBuffer> managed_tf_buffer_{nullptr};
-  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_broadcaster_;
+  rclcpp::Node::SharedPtr node_{nullptr};
+  rclcpp::TimerBase::SharedPtr timer_{nullptr};
+  std::unique_ptr<managed_transform_buffer::ManagedTransformBuffer> managed_tf_buffer_{nullptr};
+  std::unique_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_{nullptr};
+  std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_{nullptr};
+  geometry_msgs::msg::TransformStamped tf_map_to_base_;
   geometry_msgs::msg::TransformStamped tf_base_to_lidar_top_;
   geometry_msgs::msg::TransformStamped tf_base_to_lidar_right_;
+  Eigen::Matrix4f eigen_map_to_base_;
   Eigen::Matrix4f eigen_base_to_lidar_top_;
   Eigen::Matrix4f eigen_base_to_lidar_right_;
-  std::unique_ptr<sensor_msgs::msg::PointCloud2> cloud_in_;
+  std::unique_ptr<sensor_msgs::msg::PointCloud2> cloud_in_{nullptr};
   double precision_;
+  rclcpp::Time time_;
+  rclcpp::Duration timeout_ = rclcpp::Duration::from_seconds(1);
 
   geometry_msgs::msg::TransformStamped generateTransformMsg(
     const int32_t seconds, const uint32_t nanoseconds, const std::string & parent_frame,
     const std::string & child_frame, double x, double y, double z, double qx, double qy, double qz,
     double qw)
   {
-    rclcpp::Time timestamp(seconds, nanoseconds, RCL_ROS_TIME);
+    rclcpp::Time timestamp(seconds, nanoseconds, node_->get_clock()->get_clock_type());
     geometry_msgs::msg::TransformStamped tf_msg;
     tf_msg.header.stamp = timestamp;
     tf_msg.header.frame_id = parent_frame;
@@ -69,23 +72,45 @@ protected:
     return tf_msg;
   }
 
+  void broadcastDynamicTf(geometry_msgs::msg::TransformStamped transform, uint32_t seconds = 1)
+  {
+    timer_ = node_->create_wall_timer(std::chrono::milliseconds(100), [this, transform]() -> void {
+      tf_broadcaster_->sendTransform(transform);
+    });
+
+    rclcpp::Rate r(10);
+    rclcpp::spin_some(node_);
+    for (uint32_t i = 0; i < 10u * seconds; ++i) {
+      r.sleep();
+      rclcpp::spin_some(node_);
+    }
+
+    timer_->cancel();
+    timer_->reset();
+  }
+
   void SetUp() override
   {
-    node_ = std::make_unique<rclcpp::Node>("test_managed_transform_buffer");
+    node_ = std::make_shared<rclcpp::Node>("test_managed_transform_buffer");
     managed_tf_buffer_ =
-      std::make_unique<managed_transform_buffer::ManagedTransformBuffer>(node_.get(), true);
-    tf_broadcaster_ = std::make_unique<tf2_ros::StaticTransformBroadcaster>(node_);
+      std::make_unique<managed_transform_buffer::ManagedTransformBuffer>(node_->get_clock());
+    static_tf_broadcaster_ = std::make_unique<tf2_ros::StaticTransformBroadcaster>(node_);
+    tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(node_);
 
+    tf_map_to_base_ = generateTransformMsg(
+      10, 100'000'000, "map", "base_link", 120.0, 240.0, 1.0, 0.0, 0.0, 0.0, 1.0);
     tf_base_to_lidar_top_ = generateTransformMsg(
       10, 100'000'000, "base_link", "lidar_top", 0.690, 0.000, 2.100, -0.007, -0.007, 0.692, 0.722);
     tf_base_to_lidar_right_ = generateTransformMsg(
       10, 100'000'000, "base_link", "lidar_right", 0.0, -0.56362, -0.30555, 0.244, 0.248, 0.665,
       0.661);
+    eigen_map_to_base_ = tf2::transformToEigen(tf_map_to_base_).matrix().cast<float>();
     eigen_base_to_lidar_top_ = tf2::transformToEigen(tf_base_to_lidar_top_).matrix().cast<float>();
     eigen_base_to_lidar_right_ =
       tf2::transformToEigen(tf_base_to_lidar_right_).matrix().cast<float>();
     cloud_in_ = std::make_unique<sensor_msgs::msg::PointCloud2>();
     precision_ = 0.01;
+    time_ = rclcpp::Time(10, 100'000'000);
 
     // Set up the fields for x, y, and z coordinates
     cloud_in_->fields.resize(3);
@@ -109,158 +134,221 @@ protected:
 
     // Set up cloud header
     cloud_in_->header.frame_id = "lidar_top";
-    cloud_in_->header.stamp = rclcpp::Time(10, 100'000'000);
+    cloud_in_->header.stamp = time_;
 
     ASSERT_TRUE(rclcpp::ok());
   }
 
-  void TearDown() override { managed_tf_buffer_.reset(); }
+  void TearDown() override {}
 };
 
 TEST_F(TestManagedTransformBuffer, TestReturn)
 {
-  tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
+  static_tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
 
   auto eigen_transform =
-    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "lidar_top");
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "lidar_top", time_, timeout_);
   EXPECT_TRUE(eigen_transform.has_value());
 
-  auto tf2_transform = managed_tf_buffer_->getTransform<tf2::Transform>("base_link", "lidar_top");
+  auto tf2_transform =
+    managed_tf_buffer_->getTransform<tf2::Transform>("base_link", "lidar_top", time_, timeout_);
   EXPECT_TRUE(tf2_transform.has_value());
 
   auto tf_msg_transform = managed_tf_buffer_->getTransform<geometry_msgs::msg::TransformStamped>(
-    "base_link", "lidar_top");
+    "base_link", "lidar_top", time_, timeout_);
   EXPECT_TRUE(tf_msg_transform.has_value());
+  EXPECT_TRUE(managed_tf_buffer_->isStatic());
 }
 
 TEST_F(TestManagedTransformBuffer, TestTransformNoExist)
 {
-  tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
+  static_tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
 
   auto eigen_transform =
-    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "fake_link");
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "fake_link", time_, timeout_);
   EXPECT_FALSE(eigen_transform.has_value());
+  EXPECT_TRUE(managed_tf_buffer_->isStatic());
 }
 
 TEST_F(TestManagedTransformBuffer, TestTransformBase)
 {
-  tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
-
+  static_tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
   auto eigen_base_to_lidar_top =
-    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "lidar_top");
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "lidar_top", time_, timeout_);
   ASSERT_TRUE(eigen_base_to_lidar_top.has_value());
   EXPECT_TRUE(eigen_base_to_lidar_top.value().isApprox(eigen_base_to_lidar_top_, precision_));
+  EXPECT_TRUE(managed_tf_buffer_->isStatic());
 }
 
 TEST_F(TestManagedTransformBuffer, TestTransformSameFrame)
 {
-  tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
+  static_tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
 
   auto eigen_base_to_base =
-    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "base_link");
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "base_link", time_, timeout_);
   ASSERT_TRUE(eigen_base_to_base.has_value());
   EXPECT_TRUE(eigen_base_to_base.value().isApprox(Eigen::Matrix4f::Identity(), precision_));
+  EXPECT_TRUE(managed_tf_buffer_->isStatic());
 }
 
 TEST_F(TestManagedTransformBuffer, TestTransformInverse)
 {
-  tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
+  static_tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
 
   auto eigen_lidar_top_tobase =
-    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("lidar_top", "base_link");
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("lidar_top", "base_link", time_, timeout_);
   ASSERT_TRUE(eigen_lidar_top_tobase.has_value());
   EXPECT_TRUE(
     eigen_lidar_top_tobase.value().isApprox(eigen_base_to_lidar_top_.inverse(), precision_));
+  EXPECT_TRUE(managed_tf_buffer_->isStatic());
 }
 
 TEST_F(TestManagedTransformBuffer, TestTransformNonDirect)
 {
-  tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
-  tf_broadcaster_->sendTransform(tf_base_to_lidar_right_);
+  static_tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
+  static_tf_broadcaster_->sendTransform(tf_base_to_lidar_right_);
 
   auto eigen_lidar_top_to_lidar_right =
-    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("lidar_top", "lidar_right");
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("lidar_top", "lidar_right", time_, timeout_);
   ASSERT_TRUE(eigen_lidar_top_to_lidar_right.has_value());
-  // EXPECT_TRUE(eigen_lidar_top_to_lidar_right.value().isApprox(
-  // eigen_base_to_lidar_top_.inverse() * eigen_base_to_lidar_right_, precision_));
+  EXPECT_TRUE(eigen_lidar_top_to_lidar_right.value().isApprox(
+    eigen_base_to_lidar_top_.inverse() * eigen_base_to_lidar_right_, precision_));
+  EXPECT_TRUE(managed_tf_buffer_->isStatic());
+}
+
+TEST_F(TestManagedTransformBuffer, TestTransformDynamic)
+{
+  static_tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
+  static_tf_broadcaster_->sendTransform(tf_base_to_lidar_right_);
+
+  std::future<void> future =
+    std::async(std::launch::async, [this]() { broadcastDynamicTf(tf_map_to_base_); });
+  auto eigen_map_to_base =
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("map", "base_link", time_, timeout_);
+  future.wait();
+
+  ASSERT_TRUE(eigen_map_to_base.has_value());
+  EXPECT_TRUE(eigen_map_to_base.value().isApprox(eigen_map_to_base_, precision_));
+  EXPECT_FALSE(managed_tf_buffer_->isStatic());
+
+  auto eigen_lidar_top_to_lidar_right =
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("lidar_top", "lidar_right", time_, timeout_);
+  ASSERT_TRUE(eigen_lidar_top_to_lidar_right.has_value());
+  EXPECT_TRUE(eigen_lidar_top_to_lidar_right.value().isApprox(
+    eigen_base_to_lidar_top_.inverse() * eigen_base_to_lidar_right_, precision_));
+  EXPECT_FALSE(managed_tf_buffer_->isStatic());
 }
 
 TEST_F(TestManagedTransformBuffer, TestTransformMultipleCall)
 {
-  tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
+  static_tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
 
   std::optional<Eigen::Matrix4f> eigen_transform;
-  eigen_transform = managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "fake_link");
+  eigen_transform =
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "fake_link", time_, timeout_);
   EXPECT_FALSE(eigen_transform.has_value());
 
-  eigen_transform = managed_tf_buffer_->getTransform<Eigen::Matrix4f>("lidar_top", "base_link");
+  eigen_transform =
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("lidar_top", "base_link", time_, timeout_);
   ASSERT_TRUE(eigen_transform.has_value());
   EXPECT_TRUE(eigen_transform.value().isApprox(eigen_base_to_lidar_top_.inverse(), precision_));
 
-  eigen_transform = managed_tf_buffer_->getTransform<Eigen::Matrix4f>("fake_link", "fake_link");
+  eigen_transform =
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("fake_link", "fake_link", time_, timeout_);
   ASSERT_TRUE(eigen_transform.has_value());
   EXPECT_TRUE(eigen_transform.value().isApprox(Eigen::Matrix4f::Identity(), precision_));
 
-  eigen_transform = managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "lidar_top");
+  eigen_transform =
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "lidar_top", time_, timeout_);
   ASSERT_TRUE(eigen_transform.has_value());
   EXPECT_TRUE(eigen_transform.value().isApprox(eigen_base_to_lidar_top_, precision_));
 
-  eigen_transform = managed_tf_buffer_->getTransform<Eigen::Matrix4f>("fake_link", "lidar_top");
+  eigen_transform =
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("fake_link", "lidar_top", time_, timeout_);
   EXPECT_FALSE(eigen_transform.has_value());
 
-  eigen_transform = managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "lidar_top");
+  eigen_transform =
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("base_link", "lidar_top", time_, timeout_);
   ASSERT_TRUE(eigen_transform.has_value());
   EXPECT_TRUE(eigen_transform.value().isApprox(eigen_base_to_lidar_top_, precision_));
+  EXPECT_TRUE(managed_tf_buffer_->isStatic());
+
+  std::future<void> future =
+    std::async(std::launch::async, [this]() { broadcastDynamicTf(tf_map_to_base_); });
+  auto eigen_map_to_base =
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("map", "base_link", time_, timeout_);
+  future.wait();
+  ASSERT_TRUE(eigen_map_to_base.has_value());
+  EXPECT_TRUE(eigen_map_to_base.value().isApprox(eigen_map_to_base_, precision_));
+  EXPECT_FALSE(managed_tf_buffer_->isStatic());
+
+  eigen_transform =
+    managed_tf_buffer_->getTransform<Eigen::Matrix4f>("fake_link", "fake_link", time_, timeout_);
+  ASSERT_TRUE(eigen_transform.has_value());
+  EXPECT_TRUE(eigen_transform.value().isApprox(Eigen::Matrix4f::Identity(), precision_));
+  EXPECT_FALSE(managed_tf_buffer_->isStatic());
 }
 
 TEST_F(TestManagedTransformBuffer, TestTransformEmptyPointCloud)
 {
-  tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
+  static_tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
 
   auto cloud_in = std::make_unique<sensor_msgs::msg::PointCloud2>();
   cloud_in->header.frame_id = "lidar_top";
   cloud_in->header.stamp = rclcpp::Time(10, 100'000'000);
   auto cloud_out = std::make_unique<sensor_msgs::msg::PointCloud2>();
 
-  EXPECT_FALSE(managed_tf_buffer_->transformPointcloud("lidar_top", *cloud_in, *cloud_out));
-  EXPECT_FALSE(managed_tf_buffer_->transformPointcloud("base_link", *cloud_in, *cloud_out));
-  EXPECT_FALSE(managed_tf_buffer_->transformPointcloud("fake_link", *cloud_in, *cloud_out));
+  EXPECT_FALSE(
+    managed_tf_buffer_->transformPointcloud("lidar_top", *cloud_in, *cloud_out, time_, timeout_));
+  EXPECT_FALSE(
+    managed_tf_buffer_->transformPointcloud("base_link", *cloud_in, *cloud_out, time_, timeout_));
+  EXPECT_FALSE(
+    managed_tf_buffer_->transformPointcloud("fake_link", *cloud_in, *cloud_out, time_, timeout_));
 }
 
 TEST_F(TestManagedTransformBuffer, TestTransformEmptyPointCloudNoHeader)
 {
-  tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
+  static_tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
   auto cloud_in = std::make_unique<sensor_msgs::msg::PointCloud2>();
   auto cloud_out = std::make_unique<sensor_msgs::msg::PointCloud2>();
 
-  EXPECT_FALSE(managed_tf_buffer_->transformPointcloud("lidar_top", *cloud_in, *cloud_out));
-  EXPECT_FALSE(managed_tf_buffer_->transformPointcloud("base_link", *cloud_in, *cloud_out));
-  EXPECT_FALSE(managed_tf_buffer_->transformPointcloud("fake_link", *cloud_in, *cloud_out));
+  EXPECT_FALSE(
+    managed_tf_buffer_->transformPointcloud("lidar_top", *cloud_in, *cloud_out, time_, timeout_));
+  EXPECT_FALSE(
+    managed_tf_buffer_->transformPointcloud("base_link", *cloud_in, *cloud_out, time_, timeout_));
+  EXPECT_FALSE(
+    managed_tf_buffer_->transformPointcloud("fake_link", *cloud_in, *cloud_out, time_, timeout_));
 }
 
 TEST_F(TestManagedTransformBuffer, TestTransformPointCloud)
 {
-  tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
+  static_tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
   auto cloud_out = std::make_unique<sensor_msgs::msg::PointCloud2>();
 
   // Transform cloud with header
-  EXPECT_TRUE(managed_tf_buffer_->transformPointcloud("lidar_top", *cloud_in_, *cloud_out));
-  EXPECT_TRUE(managed_tf_buffer_->transformPointcloud("base_link", *cloud_in_, *cloud_out));
-  EXPECT_FALSE(managed_tf_buffer_->transformPointcloud("fake_link", *cloud_in_, *cloud_out));
+  EXPECT_TRUE(
+    managed_tf_buffer_->transformPointcloud("lidar_top", *cloud_in_, *cloud_out, time_, timeout_));
+  EXPECT_TRUE(
+    managed_tf_buffer_->transformPointcloud("base_link", *cloud_in_, *cloud_out, time_, timeout_));
+  EXPECT_FALSE(
+    managed_tf_buffer_->transformPointcloud("fake_link", *cloud_in_, *cloud_out, time_, timeout_));
 }
 
 TEST_F(TestManagedTransformBuffer, TestTransformPointCloudNoHeader)
 {
-  tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
+  static_tf_broadcaster_->sendTransform(tf_base_to_lidar_top_);
   auto cloud_out = std::make_unique<sensor_msgs::msg::PointCloud2>();
 
   // Transform cloud without header
   auto cloud_in = std::make_unique<sensor_msgs::msg::PointCloud2>(*cloud_in_);
   cloud_in->header.frame_id = "";
   cloud_in->header.stamp = rclcpp::Time(0, 0);
-  EXPECT_FALSE(managed_tf_buffer_->transformPointcloud("lidar_top", *cloud_in, *cloud_out));
-  EXPECT_FALSE(managed_tf_buffer_->transformPointcloud("base_link", *cloud_in, *cloud_out));
-  EXPECT_FALSE(managed_tf_buffer_->transformPointcloud("fake_link", *cloud_in, *cloud_out));
+  EXPECT_FALSE(
+    managed_tf_buffer_->transformPointcloud("lidar_top", *cloud_in, *cloud_out, time_, timeout_));
+  EXPECT_FALSE(
+    managed_tf_buffer_->transformPointcloud("base_link", *cloud_in, *cloud_out, time_, timeout_));
+  EXPECT_FALSE(
+    managed_tf_buffer_->transformPointcloud("fake_link", *cloud_in, *cloud_out, time_, timeout_));
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description

* Reduce temporary TF listeners from two to one.
* Use singleton pattern for core implementation.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
