### PR TITLE
feat: rework constructor, expand API, improve logging, fix sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Library exposes a few handy function for handling TFs and PointCloud2 transforma
 
 ```cpp
 // Create a managed TF buffer
-auto managed_tf_buffer = std::make_unique<ManagedTFBuffer>(this->get_clock());
+auto managed_tf_buffer = std::make_unique<managed_transform_buffer::ManagedTransformBuffer>();
 
 // Get a transform from source_frame to target_frame
 auto tf_msg_transform = managed_tf_buffer->getTransform<geometry_msgs::msg::TransformStamped>("my_target_frame", "my_source_frame", this->now(), rclcpp::Duration::from_seconds(1));
@@ -50,4 +50,8 @@ ros2 run managed_transform_buffer example_managed_transform_buffer --ros-args -p
 
 ## Limitations
 
-- Requests for dynamic transforms with zero timeout might never succeed. This limitation is due to the fact that the listener is initialized for each transform request (till first occurrence of dynamic transform). If timeout is zero, the listener might not have enough time to fill the buffer.
+- Requests for dynamic transforms with zero timeout might never succeed. This limitation is due to the fact that the listener is initialized for each transform request (till first occurrence of dynamic transform). If timeout is zero, the listener will not have enough time to fill the buffer. This can be controlled with `discovery_timeout` parameter for `ManagedTransformBuffer` class constructor. `discovery_timeout` (default: 20ms) is used to set timeout for the first occurrence of any transform:
+
+```cpp
+auto managed_tf_buffer = std::make_unique<managed_transform_buffer::ManagedTransformBuffer>(RCL_ROS_TIME, false, tf2::durationFromSec(0.3));
+```

--- a/managed_transform_buffer/examples/example_managed_transform_buffer.cpp
+++ b/managed_transform_buffer/examples/example_managed_transform_buffer.cpp
@@ -30,8 +30,7 @@ public:
   {
     target_frame_ = declare_parameter<std::string>("target_frame", "dummy_target_frame");
     source_frame_ = declare_parameter<std::string>("source_frame", "dummy_source_frame");
-    managed_tf_buffer_ =
-      std::make_unique<managed_transform_buffer::ManagedTransformBuffer>(this->get_clock());
+    managed_tf_buffer_ = std::make_unique<managed_transform_buffer::ManagedTransformBuffer>();
     cloud_sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
       "input/cloud", rclcpp::SensorDataQoS(),
       std::bind(&ExampleNode::cloud_cb, this, std::placeholders::_1));

--- a/managed_transform_buffer/test/test_managed_transform_buffer.cpp
+++ b/managed_transform_buffer/test/test_managed_transform_buffer.cpp
@@ -92,8 +92,8 @@ protected:
   void SetUp() override
   {
     node_ = std::make_shared<rclcpp::Node>("test_managed_transform_buffer");
-    managed_tf_buffer_ =
-      std::make_unique<managed_transform_buffer::ManagedTransformBuffer>(node_->get_clock());
+    managed_tf_buffer_ = std::make_unique<managed_transform_buffer::ManagedTransformBuffer>(
+      node_->get_clock()->get_clock_type());
     static_tf_broadcaster_ = std::make_unique<tf2_ros::StaticTransformBroadcaster>(node_);
     tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(node_);
 


### PR DESCRIPTION
## Description

* Reworked class constructor:
  * Clock is not shared with top node anymore - inadequate for singleton pattern. Instead, it is defined via passed clock type.
  * Allow to force dynamic TF listener during initialization via `force_dynamic` argument.
  * Add `discovery_timeout` to handle first TF requests.
* Add `getLatestTransform`.
* Improved logging - internal logger for internal implementation. For TF requests logger is passed as an argument.
* Fixed sync. Current mutex lock placement at the TF request beginning prevents race condition. However, there might be a more complex approach for mutex locking which could enable higher parallelization. Improved locking strategy will be addressed in future PR.
* Minor style changes.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
