### PR TITLE
feat: rework mutexes

### DIFF
--- a/managed_transform_buffer/include/managed_transform_buffer/managed_transform_buffer_provider.hpp
+++ b/managed_transform_buffer/include/managed_transform_buffer/managed_transform_buffer_provider.hpp
@@ -25,11 +25,13 @@
 #include <tf2_ros/buffer.h>
 
 #include <atomic>
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <random>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -185,7 +187,7 @@ private:
    */
   TraverseResult traverseTree(
     const std::string & target_frame, const std::string & source_frame,
-    const tf2::Duration & timeout, const rclcpp::Logger & logger) const;
+    const tf2::Duration & timeout, const rclcpp::Logger & logger);
 
   /** @brief Get a dynamic transform from the TF buffer.
    *
@@ -244,8 +246,11 @@ private:
   std::unique_ptr<TreeMap> tf_tree_;
   std::mt19937 random_engine_;
   std::uniform_int_distribution<> dis_;
-  std::mutex mutex_;
+  std::shared_mutex buffer_mutex_;
+  std::shared_mutex tree_mutex_;
+  std::mutex listener_mutex_;
   std::atomic<bool> is_static_{true};
+  std::atomic<std::size_t> operational_threads_{0};
   tf2::Duration discovery_timeout_;
   rclcpp::Logger logger_;
 };

--- a/managed_transform_buffer/src/managed_transform_buffer.cpp
+++ b/managed_transform_buffer/src/managed_transform_buffer.cpp
@@ -131,7 +131,8 @@ bool ManagedTransformBuffer::transformPointcloud(
 {
   if (
     pcl::getFieldIndex(cloud_in, "x") == -1 || pcl::getFieldIndex(cloud_in, "y") == -1 ||
-    pcl::getFieldIndex(cloud_in, "z") == -1) {
+    pcl::getFieldIndex(cloud_in, "z") == -1 || target_frame.empty() ||
+    cloud_in.header.frame_id.empty() || cloud_in.data.empty()) {
     return false;
   }
   if (target_frame == cloud_in.header.frame_id) {


### PR DESCRIPTION
## Description

This PR replaces the global mutex with more granular locks for specific class members, improving concurrency and scalability by allowing finer control over locking individual members instead of the entire class.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
