### PR TITLE
feat: remove unnecessary async calls

### DIFF
--- a/managed_transform_buffer/include/managed_transform_buffer/managed_transform_buffer_provider.hpp
+++ b/managed_transform_buffer/include/managed_transform_buffer/managed_transform_buffer_provider.hpp
@@ -181,13 +181,12 @@ private:
    *
    * @param[in] target_frame the frame to which data should be transformed
    * @param[in] source_frame the frame where the data originated
-   * @param[in] timeout how long to block before failing
    * @param[in] logger logger, if not specified, default logger will be used
    * @return a traverse result indicating if the transform is possible and if it is static
    */
   TraverseResult traverseTree(
     const std::string & target_frame, const std::string & source_frame,
-    const tf2::Duration & timeout, const rclcpp::Logger & logger);
+    const rclcpp::Logger & logger);
 
   /** @brief Get a dynamic transform from the TF buffer.
    *


### PR DESCRIPTION
## Description

Since local TF map (tree) and TF buffer are filled in the same callback, asynchronous calls for traversing tree and getting transform are not needed anymore. Success of `lookupTranform` can be associated with already existing frames in local TF map.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
