### PR TITLE
perf: stop appending TF tree if already dynamic listener & fix logging

### DIFF
--- a/managed_transform_buffer/include/managed_transform_buffer/managed_transform_buffer_provider.hpp
+++ b/managed_transform_buffer/include/managed_transform_buffer/managed_transform_buffer_provider.hpp
@@ -145,11 +145,17 @@ private:
   /** @brief Deactivate TF listener */
   void deactivateListener();
 
-  /** @brief Register TF buffer as unknown. */
-  void registerAsUnknown();
+  /** @brief Register TF buffer as unknown
+   *
+   * @return true if successful, false otherwise
+   */
+  bool registerAsUnknown();
 
-  /** @brief Register TF buffer as dynamic. */
-  void registerAsDynamic();
+  /** @brief Register TF buffer as dynamic
+   *
+   * @return true if successful, false otherwise
+   */
+  bool registerAsDynamic();
 
   /** @brief Generate a unique node name
    *


### PR DESCRIPTION
## Description

TF tree is not used in dynamic listener, therefore callbacks don't need to update it.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
