### PR TITLE
feat: assign requested stamp for static transforms

### DIFF
--- a/managed_transform_buffer/include/managed_transform_buffer/managed_transform_buffer_provider.hpp
+++ b/managed_transform_buffer/include/managed_transform_buffer/managed_transform_buffer_provider.hpp
@@ -211,10 +211,12 @@ private:
    *
    * @param[in] target_frame the frame to which data should be transformed
    * @param[in] source_frame the frame where the data originated
+   * @param[in] time the time to be assigned to static transform
    * @return an optional containing the transform if successful, or empty if not
    */
   std::optional<TransformStamped> getStaticTransform(
-    const std::string & target_frame, const std::string & source_frame);
+    const std::string & target_frame, const std::string & source_frame,
+    const tf2::TimePoint & time);
 
   /** @brief Get an unknown (static or dynamic) transform.
    *


### PR DESCRIPTION
## Description

Timestamps for static transforms should equal requested time in call. This approach mimics default `tf2_ros::Buffer` behavior. 

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
